### PR TITLE
fix: corregido error de formato en consulta SQL (=%S a =%s)

### DIFF
--- a/src/models/ProductosModel.py
+++ b/src/models/ProductosModel.py
@@ -68,7 +68,7 @@ class ProductosModel():
             connection=get_connection()
             
             with connection.cursor() as cursor:
-                cursor.execute("""UPDATE productos SET id_producto=%S,categoria_producto=%S,id_compra=%S,caracteristicas_producto=%S,tipo_producto=%S,tamano_producto=%S,precio_producto=%S,mes_del_producto=%S,nombre_producto=%S 
+                cursor.execute("""UPDATE productos SET categoria_producto=%s,id_compra=%s,caracteristicas_producto=%s,tipo_producto=%s,tamano_producto=%s,precio_producto=%s,mes_del_producto=%s,nombre_producto=%s 
                                WHERE id_producto = %s""",(producto.categoria_producto,producto.id_compra,producto.caracteristicas_producto,producto.tipo_producto,producto.tamano_producto,producto.precio_producto,producto.mes_del_producto,producto.nombre_producto,producto.id_producto)) 
                 
                 affected_rows=cursor.rowcount
@@ -95,4 +95,4 @@ class ProductosModel():
             return affected_rows     
                 
         except Exception as ex:
-            return Exception(ex)              
+            return Exception(ex)

--- a/src/routes/Productos.py
+++ b/src/routes/Productos.py
@@ -78,7 +78,15 @@ def update_producto(id_producto):
         mes_del_producto=request.json['mes_del_producto']
         nombre_producto=request.json['nombre_producto']
         
-        producto=Productos(id_producto,categoria_producto,id_compra,caracteristicas_producto,tipo_producto,tamano_producto,precio_producto,mes_del_producto,nombre_producto)
+        producto=Productos(id_producto,
+                           categoria_producto,
+                           id_compra,
+                           caracteristicas_producto,
+                           tipo_producto,
+                           tamano_producto,
+                           precio_producto,
+                           mes_del_producto,
+                           nombre_producto)
         
         affected_rows=  ProductosModel.update_producto(producto)
         


### PR DESCRIPTION
Ok

## Summary by Sourcery

Fix the SQL update query in ProductosModel to use correct lowercase placeholders and prevent the primary key from being updated, and reformat the update_producto endpoint’s constructor arguments for readability.

Bug Fixes:
- Use lowercase %s placeholders instead of %S in the SQL UPDATE statement.
- Remove id_producto from the SET clause so it’s only used in the WHERE condition.

Enhancements:
- Reformat the Productos constructor argument list in the update_producto route for improved readability.